### PR TITLE
Fix up transfers and refunds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ libraryDependencies ++= Seq(
   "com.beachape"               %% "enumeratum-play-json" % enumeratumVersion,
   "com.iheart"                 %% "ficus"                % "1.3.4",
   "com.typesafe.scala-logging" %% "scala-logging"        % "3.4.0",
-  "com.netaporter"             %% "scala-uri"            % "0.4.13" exclude ("io.spray", "spray-json"),
+  "com.netaporter"             %% "scala-uri"            % "0.4.13" exclude ("io.spray", "spray-json_2.11"),
   "com.typesafe.play"          %% "play-json"            % "2.5.8",
   "org.spire-math"             %% "jawn-play"            % "0.10.1",
   "org.scalatest"              %% "scalatest"            % "3.0.0" % "test, it",

--- a/build.sbt
+++ b/build.sbt
@@ -44,5 +44,5 @@ libraryDependencies ++= Seq(
   "com.typesafe.play"          %% "play-json"            % "2.5.8",
   "org.spire-math"             %% "jawn-play"            % "0.10.1",
   "org.scalatest"              %% "scalatest"            % "3.0.0" % "test, it",
-  "ch.qos.logback"             % "logback-core"          % "1.1.7" % "test, it"
+  "ch.qos.logback"             % "logback-classic"       % "1.1.7" % "test, it"
 )

--- a/src/it/scala/org/mdedetrich/stripe/v1/ChargeIT.scala
+++ b/src/it/scala/org/mdedetrich/stripe/v1/ChargeIT.scala
@@ -24,7 +24,7 @@ class ChargeIT extends IntegrationTest {
         charge <- handleIdempotent(Charges.create(chargeInput(managedAccount.id, Customer(customer.id))))
       } yield charge
 
-      whenReady(chargeF) { charge =>
+      chargeF.map { charge =>
         charge shouldBe a[Charges.Charge]
         charge.source.expYear should be(LocalDate.now.plusYears(2).getYear)
         charge.source.last4 should be(CustomerIT.testCard.takeRight(4))

--- a/src/it/scala/org/mdedetrich/stripe/v1/ChargeIT.scala
+++ b/src/it/scala/org/mdedetrich/stripe/v1/ChargeIT.scala
@@ -11,26 +11,29 @@ class ChargeIT extends IntegrationTest {
   "Charge" should {
     "transfer money from a customer credit card into the bank account of a managed account and add a fee for the platform" in {
 
-      def chargeInput(destination: String, customer: Customer): ChargeInput =
-        Charges.ChargeInput.default(1500, Currency.`Euro`, capture = true, customer)
-          .copy(applicationFee = Some(100), destination = Some(destination))
 
-      val customerF = CustomerIT.createCustomerWithCC
+      val customerF = CustomerIT.createCustomerWithCC()
       val accountF = AccountIT.createManagedAccountWithBankAccount
 
       val chargeF = for {
         customer <- customerF
         managedAccount <- accountF
-        charge <- handleIdempotent(Charges.create(chargeInput(managedAccount.id, Customer(customer.id))))
+        charge <- handleIdempotent(Charges.create(ChargeIT.chargeInput(managedAccount.id, Customer(customer.id))))
       } yield charge
 
       chargeF.map { charge =>
         charge shouldBe a[Charges.Charge]
         charge.source.expYear should be(LocalDate.now.plusYears(2).getYear)
-        charge.source.last4 should be(CustomerIT.testCard.takeRight(4))
+        charge.source.last4 should be(CustomerIT.defaultTestCard.takeRight(4))
       }
 
     }
   }
 
+}
+
+object ChargeIT {
+  def chargeInput(destination: String, customer: Customer): ChargeInput =
+    Charges.ChargeInput.default(1500, Currency.`Euro`, capture = true, customer)
+      .copy(applicationFee = Some(100), destination = Some(destination))
 }

--- a/src/it/scala/org/mdedetrich/stripe/v1/ChargeIT.scala
+++ b/src/it/scala/org/mdedetrich/stripe/v1/ChargeIT.scala
@@ -33,7 +33,9 @@ class ChargeIT extends IntegrationTest {
 }
 
 object ChargeIT {
-  def chargeInput(destination: String, customer: Customer): ChargeInput =
+  def chargeInput(customer: Customer): ChargeInput = chargeInput(None, customer).copy(applicationFee = None)
+  def chargeInput(destination: String, customer: Customer): ChargeInput = chargeInput(Some(destination), customer)
+  def chargeInput(destination: Option[String], customer: Customer): ChargeInput =
     Charges.ChargeInput.default(1500, Currency.`Euro`, capture = true, customer)
-      .copy(applicationFee = Some(100), destination = Some(destination))
+      .copy(applicationFee = Some(100), destination = destination)
 }

--- a/src/it/scala/org/mdedetrich/stripe/v1/CustomerIT.scala
+++ b/src/it/scala/org/mdedetrich/stripe/v1/CustomerIT.scala
@@ -15,7 +15,7 @@ class CustomerIT extends IntegrationTest {
   "Customer" should {
     "save credit card, create customer and add token to customer" in {
 
-      val customer = CustomerIT.createCustomerWithCC
+      val customer = CustomerIT.createCustomerWithCC()
 
       customer.map { updatedCustomer =>
         updatedCustomer shouldBe a[Customer]
@@ -24,7 +24,7 @@ class CustomerIT extends IntegrationTest {
         val cards = updatedCustomer.sources.data.collect({ case c:Card => c })
         cards should have length 1
 
-        cards.head.last4 should be(CustomerIT.testCard.takeRight(4))
+        cards.head.last4 should be(CustomerIT.defaultTestCard.takeRight(4))
       }
     }
   }
@@ -33,18 +33,19 @@ class CustomerIT extends IntegrationTest {
 
 object CustomerIT {
 
-  val testCard = "4242424242424242"
+  val defaultTestCard = "4242424242424242"
+  val cardBypassingPendingCheck = "4000000000000077"
 
-  def createCustomerWithCC(implicit ec: ExecutionContext): Future[Customer] = {
+  def createCustomerWithCC(cardNumber: String = defaultTestCard)(implicit ec: ExecutionContext): Future[Customer] = {
     val in2years = OffsetDateTime.now.plusYears(2)
-      val cardData = TokenData.Card.default(in2years.getMonthValue, in2years.getYear, testCard).copy(cvc = Some("123"))
-      val tokenInput = TokenInput.default(cardData)
+    val cardData = TokenData.Card.default(in2years.getMonthValue, in2years.getYear, cardNumber).copy(cvc = Some("123"))
+    val tokenInput = TokenInput.default(cardData)
 
-      for {
-        token <- handle(Tokens.create(tokenInput)())
-        newCustomer <- handle(Customers.create(CustomerInput.default)())
-        updated <- handle(Customers.update(newCustomer.id, CustomerUpdate.default.copy(paymentSource = Some(Token(token.id))))())
-      } yield updated
+    for {
+      token <- handle(Tokens.create(tokenInput)())
+      newCustomer <- handle(Customers.create(CustomerInput.default)())
+      updated <- handle(Customers.update(newCustomer.id, CustomerUpdate.default.copy(paymentSource = Some(Token(token.id))))())
+    } yield updated
 
   }
 }

--- a/src/it/scala/org/mdedetrich/stripe/v1/CustomerIT.scala
+++ b/src/it/scala/org/mdedetrich/stripe/v1/CustomerIT.scala
@@ -8,17 +8,16 @@ import org.mdedetrich.stripe.v1.Customers.Source.Token
 import org.mdedetrich.stripe.v1.Customers.{Customer, CustomerInput, CustomerUpdate}
 import org.mdedetrich.stripe.v1.Tokens.{TokenData, TokenInput}
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class CustomerIT extends IntegrationTest {
 
   "Customer" should {
-    "should save credit card, create customer and add token to customer" in {
+    "save credit card, create customer and add token to customer" in {
 
       val customer = CustomerIT.createCustomerWithCC
 
-      whenReady(customer) { updatedCustomer =>
+      customer.map { updatedCustomer =>
         updatedCustomer shouldBe a[Customer]
 
         updatedCustomer.sources.data should have length 1
@@ -36,7 +35,7 @@ object CustomerIT {
 
   val testCard = "4242424242424242"
 
-  def createCustomerWithCC: Future[Customer] = {
+  def createCustomerWithCC(implicit ec: ExecutionContext): Future[Customer] = {
     val in2years = OffsetDateTime.now.plusYears(2)
       val cardData = TokenData.Card.default(in2years.getMonthValue, in2years.getYear, testCard).copy(cvc = Some("123"))
       val tokenInput = TokenInput.default(cardData)

--- a/src/it/scala/org/mdedetrich/stripe/v1/FileUploadIT.scala
+++ b/src/it/scala/org/mdedetrich/stripe/v1/FileUploadIT.scala
@@ -13,7 +13,7 @@ class FileUploadIT extends IntegrationTest{
       val is = getClass.getResourceAsStream("/id-card.jpg")
       val uploadF = handle(FileUploads.upload(Purpose.IdentityDocument, s"file-upload-${OffsetDateTime.now}.jpg", is))
 
-      whenReady(uploadF) { u =>
+      uploadF.map { u =>
         u shouldBe a[FileUpload]
       }
     }

--- a/src/it/scala/org/mdedetrich/stripe/v1/IntegrationTest.scala
+++ b/src/it/scala/org/mdedetrich/stripe/v1/IntegrationTest.scala
@@ -1,14 +1,10 @@
 package org.mdedetrich.stripe.v1
 
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{AsyncWordSpec, Matchers}
 
 import scala.concurrent.ExecutionContext
 
-trait IntegrationTest extends WordSpec with Matchers with ScalaFutures with DefaultExecutionContext{
-  implicit val defaultPatience = PatienceConfig(timeout = Span(10, Seconds), interval = Span(100, Millis))
-}
+trait IntegrationTest extends AsyncWordSpec with Matchers with DefaultExecutionContext
 
 trait DefaultExecutionContext {
   implicit val ec = ExecutionContext.global

--- a/src/it/scala/org/mdedetrich/stripe/v1/RefundIT.scala
+++ b/src/it/scala/org/mdedetrich/stripe/v1/RefundIT.scala
@@ -1,0 +1,26 @@
+package org.mdedetrich.stripe.v1
+
+import org.mdedetrich.stripe.Config._
+import org.mdedetrich.stripe.v1.Charges.Source.Customer
+import org.mdedetrich.stripe.v1.Refunds.{Reason, RefundInput}
+import org.scalatest.ParallelTestExecution
+
+class RefundIT extends IntegrationTest with ParallelTestExecution {
+
+  "Refund" should {
+    "refund a charge" in {
+
+      val customerF = CustomerIT.createCustomerWithCC(CustomerIT.cardBypassingPendingCheck)
+
+      val f = for {
+        customer <- customerF
+        charge <- handleIdempotent(Charges.create(ChargeIT.chargeInput(Customer(customer.id))))
+        refund <- handleIdempotent(Refunds.create(RefundInput.default(charge.id, Reason.RequestedByCustomer)))
+      } yield refund
+
+      f.map { refund =>
+        refund.amount should be(1500)
+      }
+    }
+  }
+}

--- a/src/it/scala/org/mdedetrich/stripe/v1/TransferIT.scala
+++ b/src/it/scala/org/mdedetrich/stripe/v1/TransferIT.scala
@@ -1,0 +1,34 @@
+package org.mdedetrich.stripe.v1
+
+import org.mdedetrich.stripe.Config._
+import org.mdedetrich.stripe.v1.BankAccountsPaymentSource.BankAccount
+import org.mdedetrich.stripe.v1.Charges.Source.Customer
+import org.mdedetrich.stripe.v1.Transfers.TransferInput
+import org.scalatest.ParallelTestExecution
+
+class TransferIT extends IntegrationTest with ParallelTestExecution {
+
+  "Transfer" should {
+    "transfer money from credit card to bank account" in {
+
+      val customerF = CustomerIT.createCustomerWithCC(CustomerIT.cardBypassingPendingCheck)
+      val accountF = AccountIT.createManagedAccountWithBankAccount
+
+      val f = for {
+        managedAccount <- accountF
+        customer <- customerF
+        _ <- handleIdempotent(Charges.create(ChargeIT.chargeInput(managedAccount.id, Customer(customer.id))))
+        transfer <- handleIdempotent(Transfers.create(TransferInput.default(1400, Currency.`Euro`, "default_for_currency", stripeAccount = Some(managedAccount.id))))
+      } yield (transfer, managedAccount)
+
+      f.map { case (transfer, managedAccount) =>
+        transfer.id should startWith("tr")
+        transfer.amount should be(1400)
+        val bankAccount = managedAccount.externalAccounts.data.collect({ case b:BankAccount => b }).head
+        transfer.destination should be(bankAccount.id)
+      }
+
+    }
+
+  }
+}

--- a/src/main/scala/org/mdedetrich/stripe/PostParams.scala
+++ b/src/main/scala/org/mdedetrich/stripe/PostParams.scala
@@ -3,7 +3,7 @@ package org.mdedetrich.stripe
 trait PostParams[T] {
   def toMap(t: T): Map[String, String]
 
-  def flatten[K, V](input: Map[K, Option[V]]): Map[K, V] = input.collect({ case (k, Some(v)) => (k, v) })
+  def flatten[K, V](input: Map[K, Option[V]]): Map[K, V] = PostParams.flatten(input)
 }
 
 object PostParams {
@@ -38,4 +38,10 @@ object PostParams {
         (s"$prefix[$first][$rest", value)
       case (key, value) => (s"$prefix[$key]", value)
     })
+
+  def params[T](transformer: T => Map[String, String]): PostParams[T] = new PostParams[T] {
+    override def toMap(t: T) = transformer(t)
+  }
+
+  def flatten[K, V](input: Map[K, Option[V]]): Map[K, V] = input.collect({ case (k, Some(v)) => (k, v) })
 }

--- a/src/main/scala/org/mdedetrich/stripe/v1/Transfers.scala
+++ b/src/main/scala/org/mdedetrich/stripe/v1/Transfers.scala
@@ -365,7 +365,11 @@ object Transfers extends LazyLogging {
 
     val finalUrl = endpoint.url + "/v1/transfers"
 
-    createRequestPOST[Transfer](finalUrl, postFormParameters, idempotencyKey, logger, stripeAccount = transferInput.stripeAccount)
+    createRequestPOST[Transfer](finalUrl,
+                                postFormParameters,
+                                idempotencyKey,
+                                logger,
+                                stripeAccount = transferInput.stripeAccount)
   }
 
   def get(id: String)(implicit apiKey: ApiKey, endpoint: Endpoint): Future[Try[Transfer]] = {

--- a/src/main/scala/org/mdedetrich/stripe/v1/Transfers.scala
+++ b/src/main/scala/org/mdedetrich/stripe/v1/Transfers.scala
@@ -289,6 +289,7 @@ object Transfers extends LazyLogging {
     *                            longer than 22 characters will return an error.
     *                            Note: Most banks will truncate this information and/or display it inconsistently.
     *                            Some may not display it at all.
+    * @param stripeAccount       The Stripe Connect managed account on whose behalf the transfer should be initiated.
     * @param sourceType          The source balance to draw this transfer from.
     *                            Balances for different payment sources are kept separately.
     *                            You can find the amounts with the balances API. Valid options are:
@@ -304,8 +305,6 @@ object Transfers extends LazyLogging {
                            metadata: Option[Map[String, String]],
                            sourceTransaction: Option[String],
                            statementDescriptor: Option[String],
-                           // https://stripe.com/docs/connect/bank-transfers#standard-transfers
-                           // TODO: add documentation
                            stripeAccount: Option[String],
                            sourceType: Option[SourceType]) {
     statementDescriptor match {

--- a/src/test/resources/refund.json
+++ b/src/test/resources/refund.json
@@ -1,0 +1,13 @@
+{
+  "id": "re_20OUr9J6y4jvjvHAKUY47to",
+  "object": "refund",
+  "amount": 1500,
+  "balance_transaction": "txn_19OUr9J6y4jvjvHhCDNM1SqP",
+  "charge": "ch_19OUr8J6y4jvjvHhYLlNCDG6",
+  "created": 1481214891,
+  "currency": "eur",
+  "metadata": {},
+  "reason": "requested_by_customer",
+  "receipt_number": null,
+  "status": "succeeded"
+}

--- a/src/test/resources/transfer.json
+++ b/src/test/resources/transfer.json
@@ -1,0 +1,33 @@
+{
+  "id": "tr_19N5vuJ6y4jvjvHh8S1r8WfH",
+  "object": "transfer",
+  "amount": 1500,
+  "amount_reversed": 0,
+  "application_fee": null,
+  "balance_transaction": "txn_19N5vuJ6y4jvjvHh9Fc41j1Y",
+  "created": 1480880758,
+  "currency": "eur",
+  "date": 1480880758,
+  "description": null,
+  "destination": "acct_19N5voJ1Go5hWiNo",
+  "destination_payment": "py_19N5vuJ1Go5hWiNoZxXYXQwx",
+  "failure_code": null,
+  "failure_message": null,
+  "livemode": false,
+  "metadata": {},
+  "method": "standard",
+  "recipient": null,
+  "reversals": {
+    "object": "list",
+    "data": [],
+    "has_more": false,
+    "total_count": 0,
+    "url": "/v1/transfers/tr_19N5vuJ6y4jvjvHh8S1r8WfH/reversals"
+  },
+  "reversed": false,
+  "source_transaction": null,
+  "source_type": "card",
+  "statement_descriptor": null,
+  "status": "paid",
+  "type": "stripe_account"
+}

--- a/src/test/scala/org/mdedetrich/stripe/v1/AccountsSpec.scala
+++ b/src/test/scala/org/mdedetrich/stripe/v1/AccountsSpec.scala
@@ -3,7 +3,15 @@ package org.mdedetrich.stripe.v1
 import java.time.{DayOfWeek, LocalDate, OffsetDateTime}
 
 import org.mdedetrich.stripe.PostParams
-import org.mdedetrich.stripe.v1.Accounts.{Account, AccountInput, AccountUpdate, LegalEntity, TosAcceptance, TransferInverval, TransferSchedule}
+import org.mdedetrich.stripe.v1.Accounts.{
+  Account,
+  AccountInput,
+  AccountUpdate,
+  LegalEntity,
+  TosAcceptance,
+  TransferInverval,
+  TransferSchedule
+}
 import org.mdedetrich.stripe.v1.BankAccounts.BankAccountData
 import org.mdedetrich.stripe.v1.BankAccountsPaymentSource.BankAccount
 import org.mdedetrich.stripe.v1.Shippings.Address
@@ -12,16 +20,16 @@ import play.api.libs.json.{JsString, JsSuccess, Json}
 
 class AccountsSpec extends WordSpec with Matchers {
   val address = Address.default.copy(
-        line1 = Some("Široka ulica"),
-        line2 = Some("Apartman B1"),
-        postalCode = Some("1234"),
-        city = Some("Zadar"),
-        country = Some("HR")
-      )
+    line1 = Some("Široka ulica"),
+    line2 = Some("Apartman B1"),
+    postalCode = Some("1234"),
+    city = Some("Zadar"),
+    country = Some("HR")
+  )
 
   "Accounts" should {
     "parse JSON correctly" in {
-      val in = this.getClass.getResourceAsStream("/account.json")
+      val in   = this.getClass.getResourceAsStream("/account.json")
       val json = Json.parse(in)
 
       val JsSuccess(account, _) = json.validate[Account]
@@ -39,10 +47,10 @@ class AccountsSpec extends WordSpec with Matchers {
   "Account create POST params" should {
 
     "convert tos acceptance" in {
-      val now = OffsetDateTime.now()
-      val ip = "120.0.0.1"
+      val now    = OffsetDateTime.now()
+      val ip     = "120.0.0.1"
       val update = AccountInput.default.copy(tosAcceptance = Some(TosAcceptance(Some(now), Some(ip))))
-      val map = PostParams.toPostParams(update)
+      val map    = PostParams.toPostParams(update)
 
       map("tos_acceptance[date]") should be(now.toEpochSecond.toString)
       map("tos_acceptance[ip]") should be(ip)
@@ -50,7 +58,7 @@ class AccountsSpec extends WordSpec with Matchers {
 
     "convert address" in {
       val input = AccountInput.default.copy(legalEntity = Some(LegalEntity.default.copy(address = address)))
-      val map = PostParams.toPostParams(input)
+      val map   = PostParams.toPostParams(input)
 
       map("legal_entity[address][line1]") should be(address.line1.get)
       map("legal_entity[address][line2]") should be(address.line2.get)
@@ -60,7 +68,8 @@ class AccountsSpec extends WordSpec with Matchers {
     }
 
     "convert transfer schedule" in {
-      val input = AccountInput.default.copy(transferSchedule = Some(TransferSchedule(Some(TransferInverval.Manual), None, Some(DayOfWeek.SUNDAY))))
+      val input = AccountInput.default.copy(
+        transferSchedule = Some(TransferSchedule(Some(TransferInverval.Manual), None, Some(DayOfWeek.SUNDAY))))
       val map = PostParams.toPostParams(input)
       map("transfer_schedule[interval]") should be("manual")
       map("transfer_schedule[weekly_anchor]") should be("sunday")
@@ -71,14 +80,14 @@ class AccountsSpec extends WordSpec with Matchers {
 
     "convert default currency" in {
       val update = AccountUpdate.default.copy(defaultCurrency = Some(Currency.`Algerian Dinar`))
-      val map = PostParams.toPostParams(update)
+      val map    = PostParams.toPostParams(update)
 
       map("default_currency") should be("DZD")
     }
 
     "convert address" in {
       val update = AccountUpdate.default.copy(legalEntity = Some(LegalEntity.default.copy(address = address)))
-      val map = PostParams.toPostParams(update)
+      val map    = PostParams.toPostParams(update)
 
       map("legal_entity[address][line1]") should be(address.line1.get)
       map("legal_entity[address][line2]") should be(address.line2.get)
@@ -88,9 +97,9 @@ class AccountsSpec extends WordSpec with Matchers {
     }
 
     "convert dob" in {
-      val date = LocalDate.of(2016, 10, 6)
+      val date   = LocalDate.of(2016, 10, 6)
       val update = AccountUpdate.default.copy(legalEntity = Some(LegalEntity.default.copy(dob = Some(date))))
-      val map = PostParams.toPostParams(update)
+      val map    = PostParams.toPostParams(update)
 
       map("legal_entity[dob][year]") should be(date.getYear.toString)
       map("legal_entity[dob][month]") should be(date.getMonthValue.toString)
@@ -99,8 +108,9 @@ class AccountsSpec extends WordSpec with Matchers {
 
     "convert name" in {
       val first = "Debbie"
-      val last = "Harry"
-      val update = AccountUpdate.default.copy(legalEntity = Some(LegalEntity.default.copy(firstName = Some(first), lastName = Some(last))))
+      val last  = "Harry"
+      val update = AccountUpdate.default.copy(
+        legalEntity = Some(LegalEntity.default.copy(firstName = Some(first), lastName = Some(last))))
       val map = PostParams.toPostParams(update)
 
       map("legal_entity[first_name]") should be(first)
@@ -108,10 +118,10 @@ class AccountsSpec extends WordSpec with Matchers {
     }
 
     "convert tos acceptance" in {
-      val now = OffsetDateTime.parse("2016-10-06T13:40:43Z")
+      val now       = OffsetDateTime.parse("2016-10-06T13:40:43Z")
       val ipAddress = "fd45:69e1:4b4e::"
-      val update = AccountUpdate.default.copy(tosAcceptance = Some(TosAcceptance(Some(now), Some(ipAddress))))
-      val map = PostParams.toPostParams(update)
+      val update    = AccountUpdate.default.copy(tosAcceptance = Some(TosAcceptance(Some(now), Some(ipAddress))))
+      val map       = PostParams.toPostParams(update)
 
       map("tos_acceptance[date]") should be("1475761243")
       map("tos_acceptance[ip]") should be(ipAddress)
@@ -119,17 +129,17 @@ class AccountsSpec extends WordSpec with Matchers {
 
     "convert external account data" in {
       val bankAccount = BankAccountData.Source.Object.default("DE89370400440532013000", "DE", Currency.`Euro`)
-      val update = AccountUpdate.default.copy(externalAccount = Some(bankAccount))
-      val map = PostParams.toPostParams(update)
+      val update      = AccountUpdate.default.copy(externalAccount = Some(bankAccount))
+      val map         = PostParams.toPostParams(update)
 
       map("external_account[object]") should be("bank_account")
     }
 
     "convert external account token" in {
-      val token = "bach:the-complete-organ-works"
+      val token       = "bach:the-complete-organ-works"
       val bankAccount = BankAccountData.Source.Token(token)
-      val update = AccountUpdate.default.copy(externalAccount = Some(bankAccount))
-      val map = PostParams.toPostParams(update)
+      val update      = AccountUpdate.default.copy(externalAccount = Some(bankAccount))
+      val map         = PostParams.toPostParams(update)
 
       map("external_account") should be(token)
     }

--- a/src/test/scala/org/mdedetrich/stripe/v1/ChargesSpec.scala
+++ b/src/test/scala/org/mdedetrich/stripe/v1/ChargesSpec.scala
@@ -9,7 +9,7 @@ class ChargesSpec extends WordSpec with Matchers {
 
   "Charges" should {
     "parse JSON correctly" in {
-      val in = getClass.getResourceAsStream("/charge.json")
+      val in   = getClass.getResourceAsStream("/charge.json")
       val json = Json.parse(in)
 
       val JsSuccess(account, _) = json.validate[Charge]
@@ -27,11 +27,11 @@ class ChargesSpec extends WordSpec with Matchers {
 
       // must be here for the next line to not throw an NPE
       Currency.lowerCaseNamesToValuesMap
-      val input = Charges.ChargeInput.default(100, Currency.`Euro`, capture = true, customerSource)
+      val input  = Charges.ChargeInput.default(100, Currency.`Euro`, capture = true, customerSource)
       val params = PostParams.toPostParams(input)
 
       params("customer") should be(customerId)
-      params should not contain key ("source")
+      params should not contain key("source")
     }
 
   }

--- a/src/test/scala/org/mdedetrich/stripe/v1/CustomersSpec.scala
+++ b/src/test/scala/org/mdedetrich/stripe/v1/CustomersSpec.scala
@@ -10,7 +10,7 @@ class CustomersSpec extends WordSpec with Matchers {
 
   "Customers" should {
     "parse JSON correctly" in {
-      val in = getClass.getResourceAsStream("/customer.json")
+      val in   = getClass.getResourceAsStream("/customer.json")
       val json = Json.parse(in)
 
       val JsSuccess(customer, _) = json.validate[Customer]
@@ -19,7 +19,7 @@ class CustomersSpec extends WordSpec with Matchers {
     }
 
     "convert to JSON" in {
-      val in = getClass.getResourceAsStream("/customer.json")
+      val in        = getClass.getResourceAsStream("/customer.json")
       val inputJson = Json.parse(in)
 
       val JsSuccess(customer, _) = inputJson.validate[Customer]
@@ -33,15 +33,15 @@ class CustomersSpec extends WordSpec with Matchers {
   "Customer update POST params" should {
 
     "convert payment source" in {
-      val token = "radiohead"
-      val update = CustomerUpdate.default.copy(paymentSource = Some(Token(token)))
+      val token      = "radiohead"
+      val update     = CustomerUpdate.default.copy(paymentSource = Some(Token(token)))
       val postParams = PostParams.toPostParams(update)
       postParams should be(Map("source" -> token))
     }
 
     "convert default source" in {
-      val id = "georgio-moroder"
-      val update = CustomerUpdate.default.copy(defaultSource = Some(id))
+      val id         = "georgio-moroder"
+      val update     = CustomerUpdate.default.copy(defaultSource = Some(id))
       val postParams = PostParams.toPostParams(update)
       postParams should be(Map("default_source" -> id))
     }

--- a/src/test/scala/org/mdedetrich/stripe/v1/FileUploadSpec.scala
+++ b/src/test/scala/org/mdedetrich/stripe/v1/FileUploadSpec.scala
@@ -7,7 +7,7 @@ import play.api.libs.json.{JsSuccess, Json}
 class FileUploadSpec extends WordSpec with Matchers {
   "File Upload" should {
     "parse JSON correctly" in {
-      val in = this.getClass.getResourceAsStream("/file-upload.json")
+      val in   = this.getClass.getResourceAsStream("/file-upload.json")
       val json = Json.parse(in)
 
       val JsSuccess(fileUpload, _) = json.validate[FileUpload]

--- a/src/test/scala/org/mdedetrich/stripe/v1/PostParamsSpec.scala
+++ b/src/test/scala/org/mdedetrich/stripe/v1/PostParamsSpec.scala
@@ -7,8 +7,8 @@ class PostParamsSpec extends WordSpec with Matchers {
   "Post params" should {
     "convert map to Stripe post params" in {
 
-      val email = "hans@horst.de"
-      val meta = Map("email" -> email)
+      val email  = "hans@horst.de"
+      val meta   = Map("email" -> email)
       val params = PostParams.toPostParams("user", meta)
       params should be(Map("user[email]" -> email))
     }

--- a/src/test/scala/org/mdedetrich/stripe/v1/RefundsSpec.scala
+++ b/src/test/scala/org/mdedetrich/stripe/v1/RefundsSpec.scala
@@ -1,0 +1,19 @@
+package org.mdedetrich.stripe.v1
+
+import org.mdedetrich.stripe.v1.Refunds.Refund
+import org.scalatest.{Matchers, WordSpec}
+import play.api.libs.json.{JsSuccess, Json}
+
+class RefundsSpec extends WordSpec with Matchers {
+
+  "Refunds" should {
+    "parse JSON correctly" in {
+      val in   = getClass.getResourceAsStream("/refund.json")
+      val json = Json.parse(in)
+
+      val JsSuccess(account, _) = json.validate[Refund]
+      account.id should be("re_20OUr9J6y4jvjvHAKUY47to")
+    }
+  }
+
+}

--- a/src/test/scala/org/mdedetrich/stripe/v1/TokensSpec.scala
+++ b/src/test/scala/org/mdedetrich/stripe/v1/TokensSpec.scala
@@ -7,7 +7,7 @@ import play.api.libs.json.{JsSuccess, Json}
 class TokensSpec extends WordSpec with Matchers {
   "Tokens" should {
     "parse bank account token JSON correctly" in {
-      val in = getClass.getResourceAsStream("/bank-account-token.json")
+      val in   = getClass.getResourceAsStream("/bank-account-token.json")
       val json = Json.parse(in)
 
       val JsSuccess(account, _) = json.validate[Token]
@@ -15,7 +15,7 @@ class TokensSpec extends WordSpec with Matchers {
     }
 
     "parse credit card token JSON correctly" in {
-      val in = getClass.getResourceAsStream("/credit-card-token.json")
+      val in   = getClass.getResourceAsStream("/credit-card-token.json")
       val json = Json.parse(in)
 
       val JsSuccess(account, _) = json.validate[Token]

--- a/src/test/scala/org/mdedetrich/stripe/v1/TransfersSpec.scala
+++ b/src/test/scala/org/mdedetrich/stripe/v1/TransfersSpec.scala
@@ -1,0 +1,19 @@
+package org.mdedetrich.stripe.v1
+
+import org.mdedetrich.stripe.v1.Transfers.Transfer
+import org.scalatest.{Matchers, WordSpec}
+import play.api.libs.json.{JsSuccess, Json}
+
+class TransfersSpec extends WordSpec with Matchers {
+
+  "Transfers" should {
+    "parse JSON correctly" in {
+      val in = getClass.getResourceAsStream("/transfer.json")
+      val json = Json.parse(in)
+
+      val JsSuccess(account, _) = json.validate[Transfer]
+      account.id should be("tr_19N5vuJ6y4jvjvHh8S1r8WfH")
+    }
+  }
+
+}

--- a/src/test/scala/org/mdedetrich/stripe/v1/TransfersSpec.scala
+++ b/src/test/scala/org/mdedetrich/stripe/v1/TransfersSpec.scala
@@ -8,7 +8,7 @@ class TransfersSpec extends WordSpec with Matchers {
 
   "Transfers" should {
     "parse JSON correctly" in {
-      val in = getClass.getResourceAsStream("/transfer.json")
+      val in   = getClass.getResourceAsStream("/transfer.json")
       val json = Json.parse(in)
 
       val JsSuccess(account, _) = json.validate[Transfer]


### PR DESCRIPTION
This implements a few thing:

- integration tests use `AsyncWordSpec` and hence return a Future[Assertion]
- Transfers can be made on behalf of a Stripe Connect account. In this case a special HTTP header must be set. Therefore the createRequestPOST method was extended to allow for this.
- Fix up refunds
- Apply scalafmt to test files