### PR TITLE
Use release plugin to manage versioning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import ReleaseTransformations._
+
 name := "stripe-scala"
 
 val currentScalaVersion = "2.11.8"
@@ -7,8 +9,6 @@ scalaVersion := currentScalaVersion
 crossScalaVersions := Seq(currentScalaVersion)
 
 organization := "org.mdedetrich"
-
-version := "0.1.2"
 
 scalacOptions ++= Seq(
   "-target:jvm-1.8",
@@ -58,5 +58,20 @@ developers := List(
 licenses += ("BSD 3 Clause", url("https://opensource.org/licenses/BSD-3-Clause"))
 
 pomIncludeRepository := (_ => false)
+
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  runTest,
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  ReleaseStep(action = Command.process("publishSigned", _)),
+  setNextVersion,
+  commitNextVersion,
+  ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),
+  pushChanges
+)
 
 parallelExecution in IntegrationTest := false

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.6.3")
+
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.4")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.2.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.0-SNAPSHOT"
+version in ThisBuild := "0.1.3-SNAPSHOT"


### PR DESCRIPTION
This PR adds the sbt release plugin.

It automates setting the version (by putting it in version.sbt).

If you want to release to Sonatype/Maven Central just do a
```
sbt release
```
and answer a few questions (sensible defaults set). The version number is automatically increased.

More info: https://github.com/sbt/sbt-release