### PR TITLE
Allow token source for charges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,8 @@ before_cache:
 script: sbt ++$TRAVIS_SCALA_VERSION test it:test
 env:
   secure: fgCX9/AQpXyQysSpd20dNLFmdzqNr+jEj195D3D5MMT4dC3oH6y2ksY/QJJqEpjAcG5JPgJmg5aAkUxvXMsxcom7xOatGSD/0iE4sAJNwyoLRP5HB/m35F2EgDQgS8Fs++AARgHIKdg19cKkaCfSA32l6iHg+TyMYfxGrFoT6dOKUIqhhPbJLzYT2C1Z3JqO3Zd/eWNxToJa9N8wamrTO8tQJuAtcPrLrfJBy9P+jy++0EkyhMRMPHCk9hY4IS8GeOR4momSWMADxdmPUbHlFVncDOK1B1e7HxPaHJgYLCXBNBk1FWhE9PyY61iBqMZ/LKlEf3lTRx0GbPWXX2SzxNkFLkvHpFYDT5D9OMeNChMQLE/zyv8eQanTF4Bjv7W3ELGDWB3GzcWfTdNcc2HOC39f8nGZVVFTedQF0j6/mJ67OPMf93EQa5k/0qmRCfu0WXTRzItmjEYQn/Km7Y/8vaclbuW1s/bh6l+SO2Z8Yv2XTTyBe18HxoePO/fRg/XvSAJGzepNCBGbJrXM/N6UWyNVxdZcfvXgGVMaivxtMCb0EM/rJ+Q+20N3V1H6wNo/yu3ygKHjEhmLweldyRygqBq9YZFNzILUATCz9cMbheOCowNLLKA23hbaMLg0PWic2o+kkBsVtyhpoGz7CFWa/H7UBJd2RC8Iqb4Hgy2N70M=
+
+notifications:
+  email:
+    on_success: change # default: change
+    on_failure: always # default: always

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ libraryDependencies ++= Seq(
 
 To get the latest version please check the [Maven repository search](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.mdedetrich%22%20AND%20a%3A%22stripe-scala_2.11%22).
 
-## TODO for release
+## TODO for 1.0 release
 - [ ] Add all operations for all endpoints
 - [x] Add tests
 - [ ] Shade jawn/enumeratum if possible. These dependencies don't need to be exposed to users
@@ -48,7 +48,17 @@ To get the latest version please check the [Maven repository search](http://sear
   - [x] list
   - [x] delete
 - [ ] Clean up/refactor code (still a lot of duplication)
-- [ ] Webhooks/Events
+- [x] Webhooks/Events
+
+## Examples
+
+There are integration tests that show how the library is intended to be used.
+
+- [Create token for a credit card and charge it](https://github.com/mdedetrich/stripe-scala/blob/token-input/src/it/scala/org/mdedetrich/stripe/v1/ChargeIT.scala#L15)
+- [Create a customer, add token and charge it](https://github.com/mdedetrich/stripe-scala/blob/master/src/it/scala/org/mdedetrich/stripe/v1/CustomerIT.scala#L18)
+- [Create managed/connected account and payout money to it](https://github.com/mdedetrich/stripe-scala/blob/master/src/it/scala/org/mdedetrich/stripe/v1/AccountIT.scala#L32)
+- [Payout money to a connected account](https://github.com/mdedetrich/stripe-scala/blob/master/src/it/scala/org/mdedetrich/stripe/v1/TransferIT.scala#L11)
+- [Refund a charge](https://github.com/mdedetrich/stripe-scala/blob/master/src/it/scala/org/mdedetrich/stripe/v1/RefundIT.scala#L10)
 
 ## Usage
 Stripe Api key and url endpoint are provided implicitly by using the `org.mdedetrich.stripe.ApiKey` and `org.mdedetrich.stripe.Endpoint`
@@ -83,8 +93,8 @@ For the most part you will want to use `handleIdempotent`/`handle` however if yo
 more fine grained control over potential errors then you can use the various `.create`/`.get` methods
 
 ### Building case classes
-The stripe object models in stripe-scala have named parameters set to default values which simplifies creating
-the stripe models
+The Stripe object models in stripe-scala have named parameters set to default values which simplifies creating
+the Stripe models
 
 ```scala
 import org.mdedetrich.stripe.v1.Customers._

--- a/src/it/scala/org/mdedetrich/stripe/v1/ChargeIT.scala
+++ b/src/it/scala/org/mdedetrich/stripe/v1/ChargeIT.scala
@@ -1,15 +1,43 @@
 package org.mdedetrich.stripe.v1
 
-import java.time.LocalDate
+import java.time.{LocalDate, OffsetDateTime}
 
 import org.mdedetrich.stripe.Config._
-import org.mdedetrich.stripe.v1.Charges.ChargeInput
+import org.mdedetrich.stripe.v1.Charges.{ChargeInput, SourceInput}
 import org.mdedetrich.stripe.v1.Charges.Source.MaskedCard
 import org.mdedetrich.stripe.v1.Charges.SourceInput.Customer
+import org.mdedetrich.stripe.v1.Tokens.{TokenData, TokenInput}
 
 class ChargeIT extends IntegrationTest {
 
   "Charge" should {
+
+    "create token and charge it" in {
+
+      val cardNumber = "4242424242424242"
+      val in2years   = OffsetDateTime.now.plusYears(2)
+      val cardData   = TokenData.Card(in2years.getMonthValue, in2years.getYear, cardNumber).copy(cvc = Option("123"))
+      val tokenInput = TokenInput(cardData)
+
+      val chargeF = for {
+        token <- handle(Tokens.create(tokenInput)())
+        charge <- handle(
+          Charges.create(
+            Charges.ChargeInput(amount = BigDecimal(15000),
+                                Currency.`Euro`,
+                                capture = true,
+                                source = Some(SourceInput.Token(token.id))))())
+      } yield charge
+
+      chargeF.map { charge =>
+        charge shouldBe a[Charges.Charge]
+        val card = charge.source.asInstanceOf[MaskedCard]
+        card.expYear should be(LocalDate.now.plusYears(2).getYear)
+        card.last4 should be(cardNumber.takeRight(4))
+      }
+
+    }
+
     "transfer money from a customer credit card into the bank account of a managed account and add a fee for the platform" in {
 
       val customerF = CustomerIT.createCustomerWithCC()

--- a/src/main/scala/org/mdedetrich/stripe/PostParams.scala
+++ b/src/main/scala/org/mdedetrich/stripe/PostParams.scala
@@ -7,6 +7,9 @@ trait PostParams[T] {
 }
 
 object PostParams {
+  def toPostParams[T](optionOfT: Option[T])(implicit postParams: PostParams[T]): Map[String, String] =
+    optionOfT.map(postParams.toMap).getOrElse(Map.empty)
+
   def toPostParams[T](t: T)(implicit postParams: PostParams[T]): Map[String, String] = postParams.toMap(t)
 
   def toPostParams[T](prefix: String, input: Option[T])(implicit postParams: PostParams[T]): Map[String, String] =

--- a/src/main/scala/org/mdedetrich/stripe/v1/Balances.scala
+++ b/src/main/scala/org/mdedetrich/stripe/v1/Balances.scala
@@ -232,10 +232,10 @@ object Balances extends LazyLogging {
     * @return
     */
   def get(stripeAccount: Option[String] = None)(implicit apiKey: ApiKey,
-          endpoint: Endpoint,
-          client: HttpExt,
-          materializer: Materializer,
-          executionContext: ExecutionContext): Future[Try[Balance]] = {
+                                                endpoint: Endpoint,
+                                                client: HttpExt,
+                                                materializer: Materializer,
+                                                executionContext: ExecutionContext): Future[Try[Balance]] = {
     val finalUrl = endpoint.url + s"/v1/balance"
 
     createRequestGET[Balance](finalUrl, logger, stripeAccount)

--- a/src/main/scala/org/mdedetrich/stripe/v1/package.scala
+++ b/src/main/scala/org/mdedetrich/stripe/v1/package.scala
@@ -57,7 +57,7 @@ package object v1 {
     for {
       response <- client.singleRequest(req)
       _ = logger.debug(s"Received response $response")
-      parsed   <- parseStripeServerError[DeleteResponse](response, finalUrl, None, None, logger)
+      parsed <- parseStripeServerError[DeleteResponse](response, finalUrl, None, None, logger)
       result = parsed match {
         case Right(triedDeleteResponse) =>
           util.Success(triedDeleteResponse.get)
@@ -92,7 +92,7 @@ package object v1 {
     for {
       response <- client.singleRequest(req)
       _ = logger.debug(s"Received response $response")
-      parsed   <- parseStripeServerError[M](response, finalUrl, None, None, logger)
+      parsed <- parseStripeServerError[M](response, finalUrl, None, None, logger)
       result = parsed match {
         case Right(triedValue) =>
           util.Success(triedValue.get)
@@ -137,7 +137,7 @@ package object v1 {
     for {
       response <- client.singleRequest(req)
       _ = logger.debug(s"Received response $response")
-      parsed   <- parseStripeServerError[M](response, finalUrl, Option(postFormParameters), None, logger)
+      parsed <- parseStripeServerError[M](response, finalUrl, Option(postFormParameters), None, logger)
       result = parsed match {
         case Right(triedValue) =>
           util.Success(triedValue.get)

--- a/src/test/scala/org/mdedetrich/stripe/v1/ChargesSpec.scala
+++ b/src/test/scala/org/mdedetrich/stripe/v1/ChargesSpec.scala
@@ -49,22 +49,29 @@ class ChargesSpec extends WordSpec with Matchers {
       val input =
         Charges.ChargeInput(amount = BigDecimal(100), Currency.`Euro`, capture = true, source = Option(tokenSource))
       val params = PostParams.toPostParams(input)
-      println(params)
 
       params("source") should be(token)
       params should not contain key("customer")
     }
 
-
     "put card in charge params" ignore {
       val token = "tok_4I1pWcGhJbyTLyau"
 
-      val tokenSource = Charges.SourceInput.Card(expMonth = 1, expYear = 2030, number = "4111111111111111", cvc = Some("123"), None, None, None, None, None, None, None)
+      val tokenSource = Charges.SourceInput.Card(expMonth = 1,
+                                                 expYear = 2030,
+                                                 number = "4111111111111111",
+                                                 cvc = Some("123"),
+                                                 None,
+                                                 None,
+                                                 None,
+                                                 None,
+                                                 None,
+                                                 None,
+                                                 None)
 
       val input =
         Charges.ChargeInput(amount = BigDecimal(100), Currency.`Euro`, capture = true, source = Option(tokenSource))
       val params = PostParams.toPostParams(input)
-      println(params)
 
       params("source") should be(token)
       params should not contain key("customer")

--- a/src/test/scala/org/mdedetrich/stripe/v1/ChargesSpec.scala
+++ b/src/test/scala/org/mdedetrich/stripe/v1/ChargesSpec.scala
@@ -55,6 +55,20 @@ class ChargesSpec extends WordSpec with Matchers {
       params should not contain key("customer")
     }
 
+
+    "put card in charge params" ignore {
+      val token = "tok_4I1pWcGhJbyTLyau"
+
+      val tokenSource = Charges.SourceInput.Card(expMonth = 1, expYear = 2030, number = "4111111111111111", cvc = Some("123"), None, None, None, None, None, None, None)
+
+      val input =
+        Charges.ChargeInput(amount = BigDecimal(100), Currency.`Euro`, capture = true, source = Option(tokenSource))
+      val params = PostParams.toPostParams(input)
+      println(params)
+
+      params("source") should be(token)
+      params should not contain key("customer")
+    }
   }
 
 }

--- a/src/test/scala/org/mdedetrich/stripe/v1/ChargesSpec.scala
+++ b/src/test/scala/org/mdedetrich/stripe/v1/ChargesSpec.scala
@@ -41,6 +41,20 @@ class ChargesSpec extends WordSpec with Matchers {
       params should not contain key("source")
     }
 
+    "put token in charge params" in {
+      val token = "tok_4I1pWcGhJbyTLyau"
+
+      val tokenSource = Charges.SourceInput.Token(token)
+
+      val input =
+        Charges.ChargeInput(amount = BigDecimal(100), Currency.`Euro`, capture = true, source = Option(tokenSource))
+      val params = PostParams.toPostParams(input)
+      println(params)
+
+      params("source") should be(token)
+      params should not contain key("customer")
+    }
+
   }
 
 }


### PR DESCRIPTION
This fixes #35 and allows a token source in a charge.

The integration test shows how to use this feature.

Side note: I'm not sure if it is possible to have the card data as the source for a payment without creating a token first. On first glance I couldn't find this in Stripe's documentation. We might have to remove or modify the type `SourceInput.Card`.