### PR TITLE
2018 update (including circe 0.9.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_cache:
   - find $HOME/.sbt -name "*.lock" -delete
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then sbt ++$TRAVIS_SCALA_VERSION it:test fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then sbt ++$TRAVIS_SCALA_VERSION it:test; fi'
 env:
   secure: fgCX9/AQpXyQysSpd20dNLFmdzqNr+jEj195D3D5MMT4dC3oH6y2ksY/QJJqEpjAcG5JPgJmg5aAkUxvXMsxcom7xOatGSD/0iE4sAJNwyoLRP5HB/m35F2EgDQgS8Fs++AARgHIKdg19cKkaCfSA32l6iHg+TyMYfxGrFoT6dOKUIqhhPbJLzYT2C1Z3JqO3Zd/eWNxToJa9N8wamrTO8tQJuAtcPrLrfJBy9P+jy++0EkyhMRMPHCk9hY4IS8GeOR4momSWMADxdmPUbHlFVncDOK1B1e7HxPaHJgYLCXBNBk1FWhE9PyY61iBqMZ/LKlEf3lTRx0GbPWXX2SzxNkFLkvHpFYDT5D9OMeNChMQLE/zyv8eQanTF4Bjv7W3ELGDWB3GzcWfTdNcc2HOC39f8nGZVVFTedQF0j6/mJ67OPMf93EQa5k/0qmRCfu0WXTRzItmjEYQn/Km7Y/8vaclbuW1s/bh6l+SO2Z8Yv2XTTyBe18HxoePO/fRg/XvSAJGzepNCBGbJrXM/N6UWyNVxdZcfvXgGVMaivxtMCb0EM/rJ+Q+20N3V1H6wNo/yu3ygKHjEhmLweldyRygqBq9YZFNzILUATCz9cMbheOCowNLLKA23hbaMLg0PWic2o+kkBsVtyhpoGz7CFWa/H7UBJd2RC8Iqb4Hgy2N70M=
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ before_cache:
   # Tricks to avoid unnecessary cache updates
   - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
   - find $HOME/.sbt -name "*.lock" -delete
-script: sbt ++$TRAVIS_SCALA_VERSION test it:test
+script:
+  - sbt ++$TRAVIS_SCALA_VERSION test
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then sbt ++$TRAVIS_SCALA_VERSION it:test fi'
 env:
   secure: fgCX9/AQpXyQysSpd20dNLFmdzqNr+jEj195D3D5MMT4dC3oH6y2ksY/QJJqEpjAcG5JPgJmg5aAkUxvXMsxcom7xOatGSD/0iE4sAJNwyoLRP5HB/m35F2EgDQgS8Fs++AARgHIKdg19cKkaCfSA32l6iHg+TyMYfxGrFoT6dOKUIqhhPbJLzYT2C1Z3JqO3Zd/eWNxToJa9N8wamrTO8tQJuAtcPrLrfJBy9P+jy++0EkyhMRMPHCk9hY4IS8GeOR4momSWMADxdmPUbHlFVncDOK1B1e7HxPaHJgYLCXBNBk1FWhE9PyY61iBqMZ/LKlEf3lTRx0GbPWXX2SzxNkFLkvHpFYDT5D9OMeNChMQLE/zyv8eQanTF4Bjv7W3ELGDWB3GzcWfTdNcc2HOC39f8nGZVVFTedQF0j6/mJ67OPMf93EQa5k/0qmRCfu0WXTRzItmjEYQn/Km7Y/8vaclbuW1s/bh6l+SO2Z8Yv2XTTyBe18HxoePO/fRg/XvSAJGzepNCBGbJrXM/N6UWyNVxdZcfvXgGVMaivxtMCb0EM/rJ+Q+20N3V1H6wNo/yu3ygKHjEhmLweldyRygqBq9YZFNzILUATCz9cMbheOCowNLLKA23hbaMLg0PWic2o+kkBsVtyhpoGz7CFWa/H7UBJd2RC8Iqb4Hgy2N70M=
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "stripe-scala"
 
 val currentScalaVersion = "2.12.3"
 val scala211Version     = "2.11.11"
-val circeVersion        = "0.9.2"
+val circeVersion        = "0.9.3"
 
 scalaVersion := currentScalaVersion
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "stripe-scala"
 
 val currentScalaVersion = "2.12.3"
 val scala211Version     = "2.11.11"
-val circeVersion        = "0.8.0"
+val circeVersion        = "0.9.2"
 
 scalaVersion := currentScalaVersion
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import ReleaseTransformations._
-
 name := "stripe-scala"
 
 val currentScalaVersion = "2.12.3"
@@ -65,8 +63,9 @@ licenses += ("BSD 3 Clause", url("https://opensource.org/licenses/BSD-3-Clause")
 
 pomIncludeRepository := (_ => false)
 
+import ReleaseTransformations._
 releaseCrossBuild := true
-
+releasePublishArtifactsAction := PgpKeys.publishSigned.value // Use publishSigned in publishArtifacts step
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
@@ -75,10 +74,10 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  ReleaseStep(action = Command.process("publishSigned", _), enableCrossBuild = true),
+  publishArtifacts,
   setNextVersion,
   commitNextVersion,
-  ReleaseStep(action = Command.process("sonatypeReleaseAll", _), enableCrossBuild = true),
+  releaseStepCommand("sonatypeReleaseAll"),
   pushChanges
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.1.2

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.1.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,9 @@
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.6.8")
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.4")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 
-addSbtPlugin(
-  "com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "1.0.0")
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "2.0.0")


### PR DESCRIPTION
This PR does the following:

- upgrade to sbt 1.1.1
- use sbt 1 syntax for sbt-release
- don't run integration tests on PRs (because of secret variables)
- upgrade to circe 0.9.2

Fixes #42.

~This is WIP as builds are failing due to a bintray outage: http://status.bintray.com/ :(~