### PR TITLE
Add brand to Charge.MaskedCard

### DIFF
--- a/src/main/scala/org/mdedetrich/stripe/v1/Charges.scala
+++ b/src/main/scala/org/mdedetrich/stripe/v1/Charges.scala
@@ -221,13 +221,14 @@ object Charges extends LazyLogging {
         addressLine2: Option[String],
         name: Option[String],
         addressState: Option[String],
-        addressZip: Option[String]
+        addressZip: Option[String],
+        brand: String
     ) extends Source
         with MaskedCardSource
 
     case class Account(id: String, applicationName: Option[String]) extends Source
 
-    implicit val maskedCardSourceDecoder: Decoder[MaskedCard] = Decoder.forProduct11(
+    implicit val maskedCardSourceDecoder: Decoder[MaskedCard] = Decoder.forProduct12(
       "id",
       "last4",
       "exp_month",
@@ -238,7 +239,8 @@ object Charges extends LazyLogging {
       "address_line2",
       "name",
       "address_state",
-      "address_zip"
+      "address_zip",
+      "brand"
     )(MaskedCard.apply)
 
     implicit val accountSourceDecoder: Decoder[Account] = Decoder.forProduct2(
@@ -246,7 +248,7 @@ object Charges extends LazyLogging {
       "application_name"
     )(Account.apply)
 
-    implicit val maskedCardSourceEncoder: Encoder[MaskedCard] = Encoder.forProduct12(
+    implicit val maskedCardSourceEncoder: Encoder[MaskedCard] = Encoder.forProduct13(
       "id",
       "object",
       "last4",
@@ -258,7 +260,8 @@ object Charges extends LazyLogging {
       "address_line2",
       "name",
       "address_state",
-      "address_zip"
+      "address_zip",
+      "brand"
     )(
       x =>
         (
@@ -273,7 +276,8 @@ object Charges extends LazyLogging {
           x.addressLine2,
           x.name,
           x.addressState,
-          x.addressZip
+          x.addressZip,
+          x.brand
       ))
 
     implicit val accountSourceEncoder: Encoder[Account] = Encoder.forProduct3(

--- a/src/test/scala/org/mdedetrich/stripe/v1/ChargesSpec.scala
+++ b/src/test/scala/org/mdedetrich/stripe/v1/ChargesSpec.scala
@@ -1,25 +1,35 @@
 package org.mdedetrich.stripe.v1
 
-import cats.syntax.either._
 import io.circe.parser.parse
 import org.mdedetrich.stripe.PostParams
-import org.mdedetrich.stripe.v1.Charges.Charge
+import org.mdedetrich.stripe.v1.Charges.{Charge, Source}
 import org.scalatest.{Matchers, WordSpec}
 
 class ChargesSpec extends WordSpec with Matchers {
 
   "Charges" should {
     "parse JSON correctly" in {
-      val in     = this.getClass.getResourceAsStream("/charge.json")
-      val string = scala.io.Source.fromInputStream(in).mkString
-      val json   = parse(string).toOption
-      val charge = json.flatMap(_.as[Charge].toOption).get
+      val charge = jsonToCharge("/charge.json")
 
       charge.id should be("ch_194UQpJ4y4jIjvHhJji6ElAp")
       charge.applicationFee should be(Option("fee_9OKMRHcB2CcVPD"))
-      val source = charge.source.asInstanceOf[Charges.Source.MaskedCard]
+      val source = charge.source.asInstanceOf[Source.MaskedCard]
       source.expYear should be(2018)
     }
+
+    "parse card's brand into MaskedCard" in {
+      val charge = jsonToCharge("/charge.json")
+
+      val card = charge.source.asInstanceOf[Source.MaskedCard]
+      card.brand should be("Visa")
+    }
+  }
+
+  private def jsonToCharge(jsonFname: String): Charge = {
+    val in = this.getClass.getResourceAsStream(jsonFname)
+    val string = scala.io.Source.fromInputStream(in).mkString
+    val json = parse(string).toOption
+    json.flatMap(_.as[Charge].toOption).get
   }
 
   "Charge create POST params" should {

--- a/src/test/scala/org/mdedetrich/stripe/v1/ChargesSpec.scala
+++ b/src/test/scala/org/mdedetrich/stripe/v1/ChargesSpec.scala
@@ -1,5 +1,6 @@
 package org.mdedetrich.stripe.v1
 
+import cats.syntax.either._
 import io.circe.parser.parse
 import org.mdedetrich.stripe.PostParams
 import org.mdedetrich.stripe.v1.Charges.{Charge, Source}


### PR DESCRIPTION
This is to address our need to store and display the card's brand after the charge request is done.
For the test, I removed the import cats.syntax.either._, as it was throwing a warning. 
Please have a look and let me know if you want me to change anything.